### PR TITLE
Fix score update on block removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,14 +167,11 @@
             const r = Math.floor(y / blockSize);
             if (r >= rows || c >= cols || !grid[r][c]) return;
 
-            updateLastClickInfo(0);
-
             let visited = Array.from({ length: rows }, () => Array(cols).fill(false));
             let group = floodFill(r, c, grid[r][c], visited);
             if (group.length > 1) {
                 group.forEach(block => grid[block.r][block.c] = null);
                 collapseAndRefill();
-                updateLastClickInfo(0);
                 blockSize = canvas.width / cols;
                 draw();
                 clickSound.currentTime = 0;


### PR DESCRIPTION
## Summary
- remove stray `updateLastClickInfo(0)` calls in the click handler
- only update score when a block group is removed

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841614d45c883329da7dfaf5506f89f